### PR TITLE
Added compatibility for Quick Spyglasser

### DIFF
--- a/src/main/java/top/theillusivec4/customfov/core/FovHooks.java
+++ b/src/main/java/top/theillusivec4/customfov/core/FovHooks.java
@@ -124,6 +124,9 @@ public class FovHooks {
           }
           modifier *= 1.0F - config.getBoundFov(g * 0.15F, FovType.AIMING);
         }
+        if (playerEntity.isUsingSpyglass()) {
+          modifier *= 0.1F;
+        }
         modifiedSpeed = modifier;
         return Optional.of(modifiedSpeed);
       }


### PR DESCRIPTION
Hi TheIllusiveC4,

My mod [QuickSpyglasser](https://github.com/Gluton-Official/QuickSpyglasser) is incompatible with CustomFoV because it relies on the `MathHelper;lerp(FFF)F` at the tail of `AbstractClientEntityPlayer;getSpeed()F` to make the spyglass' fov be non-exclusive to using a bow, and prevent the normal `0.1F` value from being returned in the `isUsingSpyglass()` check, while CustomFoV seems to calculate it's own fov/speed value and sets the return value for `AbstractClientEntityPlayer;getSpeed()F` at the tail before the last return, preventing any fov changes from happening on the side of QuickSpyglasser.

So, I figured the easiest solution was to simply multiply the `modifier` in `FovHooks;getModifiedSpeed` by the spyglass' `0.1F` constant under the conditional of `PlayerEntity;isUsingSpyglass()Z`, since QuickSpyglasser injects into that method and returns `true` if its spyglass keybind is pressed.

If you would like me to look into another solution on my end I can try that as well.

Thanks,
Gluton